### PR TITLE
Fix: use GH_AUTOMATION_PAT to avoid workflow-run approval gate

### DIFF
--- a/.github/workflows/create-release-json.yml
+++ b/.github/workflows/create-release-json.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        token: ${{ secrets.GH_AUTOMATION_PAT }}
 
     - name: Check for empty release.json files
       id: check-empty
@@ -49,7 +51,7 @@ jobs:
       env:
           GHCR_ORG: ${{ github.repository_owner }}
           BCORE_AUTH_TOKEN: ${{ secrets.BCORE_AUTH_TOKEN_PROD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_AUTOMATION_PAT }}
       run: |
         # Configure git
         git config --global user.name 'github-actions'

--- a/.github/workflows/onboard-new-tools.yaml
+++ b/.github/workflows/onboard-new-tools.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          token: ${{ secrets.GH_AUTOMATION_PAT }}
 
       # -----------------------------------------------------------------------
       # Step 1 – Call bcore API and compare against the bfx/ directory tree
@@ -110,7 +111,7 @@ jobs:
         id: dedup
         if: steps.detect.outputs.new-tool-count > 0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_AUTOMATION_PAT }}
           FINGERPRINT: ${{ steps.detect.outputs.fingerprint }}
         run: |
           echo "Checking for open PRs that already cover fingerprint $FINGERPRINT ..."
@@ -191,7 +192,7 @@ jobs:
       - name: Create Pull Request
         if: steps.push.outputs.branch != ''
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_AUTOMATION_PAT }}
           TOOLS_JSON:   ${{ steps.detect.outputs.tools-json }}
           TOOL_COUNT:   ${{ steps.detect.outputs.new-tool-count }}
           BRANCH:       ${{ steps.push.outputs.branch }}


### PR DESCRIPTION
## Summary
- `create-release-json.yml` and `onboard-new-tools.yaml` were opening PRs using the default `GITHUB_TOKEN`, whose bot identity (`github-actions[bot]`) has no collaborator permission on this repo.
- GitHub gates pull_request-triggered workflow runs (Discord bridge, auto-merge checks) behind manual approval when the PR author lacks write access, which is what caused PR #285's downstream runs to sit stuck as `action_required`.
- Switches both workflows to authenticate (checkout, git push, `gh pr create`/`gh pr edit`) with `GH_AUTOMATION_PAT`, matching the pattern already used in `check-bfx-releases.yml` and `auto-merge-tool-versions.yml`.

Confirmed this doesn't change auto-merge eligibility for bulk-onboarding PRs: `auto-merge-tool-versions.yml` only auto-merges PRs labeled `new tool version` with exactly 1 changed file, and neither of these workflows adds that label or produces single-file diffs when onboarding multiple tools.

## Test plan
- [ ] Next scheduled/triggered run of `Onboard New Tools` or `Generate release.json for tools` opens a PR without its downstream workflow runs requiring manual approval