### PR TITLE
Update container version for adapterremoval

### DIFF
--- a/bfx/adapterremoval/release.json
+++ b/bfx/adapterremoval/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/adapterremoval:2.3.4--pl5321haf24da9_2"]}
+{
+  "images": [
+    "quay.io/biocontainers/adapterremoval:3.0.1--pl5321h0f5e619_0",
+    "quay.io/biocontainers/adapterremoval:2.3.4--pl5321haf24da9_2"
+  ]
+}


### PR DESCRIPTION
Updates the container version for adapterremoval to match the latest Git release (3.0.1).