### PR TITLE
Authenticate GitHub API calls in check-bfx-releases to avoid rate limiting

### DIFF
--- a/.github/workflows/check-bfx-releases.yml
+++ b/.github/workflows/check-bfx-releases.yml
@@ -126,14 +126,14 @@ jobs:
                             repo_path=${repo_path%.git}
                             repo_path=${repo_path%/}  
                         #  # Get the latest release tag from GitHub API and remove leading 'v' if present
-                            latest_version=$(curl -sS  \
+                            latest_version=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
                             "https://api.github.com/repos/$repo_path/releases/latest" | jq -r '.tag_name'|sed 's/^v//')
-                            
+
                             # if no releases found, fallback to latest tag
                             if [[ -z "$latest_version" || "$latest_version" == "null" ]]; then
                                 ## Sometimes GitHub projects may not have releases, in that case use the following line instead
                                 # Fallback to fetching the latest tag if no releases are found
-                                latest_version=$(curl -sS "https://api.github.com/repos/$repo_path/tags" |jq -r '.[0].name' |sed 's/^v//')  
+                                latest_version=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/$repo_path/tags" |jq -r '.[0].name' |sed 's/^v//')
                             fi
                         
                     elif [[ "$git_url" =~ ^https://gitlab.com/ ]]; then


### PR DESCRIPTION
## Summary
- Adds `Authorization: Bearer $GH_TOKEN` to the two `api.github.com` calls in `check_git_source_tags()` in `check-bfx-releases.yml`
- Fixes #292: unauthenticated calls were hitting GitHub's 60 req/hour rate limit partway through the ~345 tools in `bfx/`, causing `jq: error ... Cannot index object with number` and silently skipping most remaining tools every week

## Test plan
- [ ] Manually trigger `Check BFX Container Releases` and confirm no `jq` errors / rate-limit failures across the full tool list