### PR TITLE
Update container version for chewbbaca

### DIFF
--- a/bfx/chewbbaca/release.json
+++ b/bfx/chewbbaca/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/chewbbaca:3.5.3--pyh106432d_1"]}
+{
+  "images": [
+    "quay.io/biocontainers/chewbbaca:3.5.4--pyh106432d_0",
+    "quay.io/biocontainers/chewbbaca:3.5.3--pyh106432d_1"
+  ]
+}


### PR DESCRIPTION
Updates the container version for chewbbaca to match the latest Git release (3.5.4).