### PR TITLE
Update container version for clair3

### DIFF
--- a/bfx/clair3/release.json
+++ b/bfx/clair3/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/clair3:2.0.0--py311hbc58adc_2"]}
+{
+  "images": [
+    "quay.io/biocontainers/clair3:2.0.2--py311hbc58adc_0",
+    "quay.io/biocontainers/clair3:2.0.0--py311hbc58adc_2"
+  ]
+}


### PR DESCRIPTION
Updates the container version for clair3 to match the latest Git release (2.0.2).