### PR TITLE
Update container version for clonalframeml

### DIFF
--- a/bfx/clonalframeml/release.json
+++ b/bfx/clonalframeml/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/clonalframeml:1.13--h9948957_2"]}
+{
+  "images": [
+    "quay.io/biocontainers/clonalframeml:1.20--hc52dbad_0",
+    "quay.io/biocontainers/clonalframeml:1.13--h9948957_2"
+  ]
+}


### PR DESCRIPTION
Updates the container version for clonalframeml to match the latest Git release (1.20).