### PR TITLE
Update container version for cnvkit

### DIFF
--- a/bfx/cnvkit/release.json
+++ b/bfx/cnvkit/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/cnvkit:0.9.14--pyhdfd78af_0",
     "quay.io/biocontainers/cnvkit:0.9.13--pyhdfd78af_0",
     "quay.io/biocontainers/cnvkit:0.9.12--pyhdfd78af_1"
   ]


### PR DESCRIPTION
Updates the container version for cnvkit to match the latest Git release (0.9.14).