### PR TITLE
Update container version for coverm

### DIFF
--- a/bfx/coverm/release.json
+++ b/bfx/coverm/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/coverm:0.7.0--hcb7b614_4"]}
+{
+  "images": [
+    "quay.io/biocontainers/coverm:0.8.0--h750ce8b_0",
+    "quay.io/biocontainers/coverm:0.7.0--hcb7b614_4"
+  ]
+}


### PR DESCRIPTION
Updates the container version for coverm to match the latest Git release (0.8.0).