### PR TITLE
Update container version for cyvcf2

### DIFF
--- a/bfx/cyvcf2/release.json
+++ b/bfx/cyvcf2/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/cyvcf2:0.32.1--py311h921ead3_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/cyvcf2:0.34.0--py312hb87923d_0",
+    "quay.io/biocontainers/cyvcf2:0.32.1--py311h921ead3_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for cyvcf2 to match the latest Git release (0.34.0).