### PR TITLE
Update container version for dendropy

### DIFF
--- a/bfx/dendropy/release.json
+++ b/bfx/dendropy/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/dendropy:5.0.8--pyhdfd78af_1"]}
+{
+  "images": [
+    "quay.io/biocontainers/dendropy:5.0.11--pyhdfd78af_0",
+    "quay.io/biocontainers/dendropy:5.0.8--pyhdfd78af_1"
+  ]
+}


### PR DESCRIPTION
Updates the container version for dendropy to match the latest Git release (5.0.11).