### PR TITLE
Update container version for dnaapler

### DIFF
--- a/bfx/dnaapler/release.json
+++ b/bfx/dnaapler/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/dnaapler:1.3.0--pyhdfd78af_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/dnaapler:1.4.0--pyhdfd78af_0",
+    "quay.io/biocontainers/dnaapler:1.3.0--pyhdfd78af_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for dnaapler to match the latest Git release (1.4.0).