### PR TITLE
Update container version for dnaio

### DIFF
--- a/bfx/dnaio/release.json
+++ b/bfx/dnaio/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/dnaio:1.2.3--py313h031d066_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/dnaio:1.2.4--py310h6813faf_0",
+    "quay.io/biocontainers/dnaio:1.2.3--py313h031d066_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for dnaio to match the latest Git release (1.2.4).