### PR TITLE
Update container version for drep

### DIFF
--- a/bfx/drep/release.json
+++ b/bfx/drep/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/drep:3.6.2--pyhdfd78af_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/drep:3.7.1--pyhdfd78af_0",
+    "quay.io/biocontainers/drep:3.6.2--pyhdfd78af_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for drep to match the latest Git release (3.7.1).