### PR TITLE
Update container version for eggnog-mapper

### DIFF
--- a/bfx/eggnog-mapper/release.json
+++ b/bfx/eggnog-mapper/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/eggnog-mapper:2.1.13--pyhdfd78af_2"]}
+{
+  "images": [
+    "quay.io/biocontainers/eggnog-mapper:2.1.14--pyhdfd78af_0",
+    "quay.io/biocontainers/eggnog-mapper:2.1.13--pyhdfd78af_2"
+  ]
+}


### PR DESCRIPTION
Updates the container version for eggnog-mapper to match the latest Git release (2.1.14).