### PR TITLE
Update container version for fastp

### DIFF
--- a/bfx/fastp/release.json
+++ b/bfx/fastp/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/fastp:1.3.3--h43da1c4_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/fastp:1.3.6--h43da1c4_0",
+    "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for fastp to match the latest Git release (1.3.6).