### PR TITLE
Update container version for fastq-dl

### DIFF
--- a/bfx/fastq-dl/release.json
+++ b/bfx/fastq-dl/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/fastq-dl:3.1.1--pyhdfd78af_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/fastq-dl:4.0.1--pyhdfd78af_0",
+    "quay.io/biocontainers/fastq-dl:3.1.1--pyhdfd78af_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for fastq-dl to match the latest Git release (4.0.1).