### PR TITLE
Update container version for hyphy

### DIFF
--- a/bfx/hyphy/release.json
+++ b/bfx/hyphy/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/hyphy:2.5.101--h526e2cb_0",
     "quay.io/biocontainers/hyphy:2.5.100--h74d3ee0_0",
     "quay.io/biocontainers/hyphy:2.5.97--h5837470_0",
     "quay.io/biocontainers/hyphy:2.5.84--hbee74ec_0"


### PR DESCRIPTION
Updates the container version for hyphy to match the latest Git release (2.5.101).