### PR TITLE
Update container version for pbmm2

### DIFF
--- a/bfx/pbmm2/release.json
+++ b/bfx/pbmm2/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/pbmm2:26.2.0--h9ee0642_0",
     "quay.io/biocontainers/pbmm2:26.1.99--h9ee0642_0",
     "quay.io/biocontainers/pbmm2:1.17.0--h9ee0642_0"
   ]


### PR DESCRIPTION
Updates the container version for pbmm2 to match the latest Git release (26.2.0).