### PR TITLE
Update container version for pharmcat3

### DIFF
--- a/bfx/pharmcat3/release.json
+++ b/bfx/pharmcat3/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/pharmcat3:3.4.0--py313h106432d_0",
     "quay.io/biocontainers/pharmcat3:3.2.0--py313h106432d_0",
     "quay.io/biocontainers/pharmcat3:3.1.1--py312h7e72e81_0"
   ]


### PR DESCRIPTION
Updates the container version for pharmcat3 to match the latest Git release (3.4.0).