### PR TITLE
Update container version for rbpbench

### DIFF
--- a/bfx/rbpbench/release.json
+++ b/bfx/rbpbench/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/rbpbench:1.1.2--pyhdfd78af_0",
     "quay.io/biocontainers/rbpbench:1.1.0--pyhdfd78af_0",
     "quay.io/biocontainers/rbpbench:1.0.6--pyhdfd78af_0"
   ]


### PR DESCRIPTION
Updates the container version for rbpbench to match the latest Git release (1.1.2).