### PR TITLE
Update container version for repeatmodeler

### DIFF
--- a/bfx/repeatmodeler/release.json
+++ b/bfx/repeatmodeler/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/repeatmodeler:2.0.7--pl5321hdfd78af_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/repeatmodeler:2.0.9--pl5321hdfd78af_0",
+    "quay.io/biocontainers/repeatmodeler:2.0.7--pl5321hdfd78af_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for repeatmodeler to match the latest Git release (2.0.9).