### PR TITLE
Update container version for vcfanno

### DIFF
--- a/bfx/vcfanno/release.json
+++ b/bfx/vcfanno/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/vcfanno:0.3.7--he881be0_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/vcfanno:0.3.9--h1079eea_0",
+    "quay.io/biocontainers/vcfanno:0.3.7--he881be0_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for vcfanno to match the latest Git release (0.3.9).