### PR TITLE
Update container version for vcflib

### DIFF
--- a/bfx/vcflib/release.json
+++ b/bfx/vcflib/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/vcflib:1.0.14--h34261f4_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/vcflib:1.0.15--h3fa9d83_1",
+    "quay.io/biocontainers/vcflib:1.0.14--h34261f4_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for vcflib to match the latest Git release (1.0.15).