### PR TITLE
Fix race condition in auto-merge-tool-versions between concurrent triggers

### DIFF
--- a/.github/workflows/auto-merge-tool-versions.yml
+++ b/.github/workflows/auto-merge-tool-versions.yml
@@ -20,6 +20,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: auto-merge-pr-${{ github.event.pull_request.number || 'dispatch' }}
+  cancel-in-progress: false
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
@@ -47,13 +51,19 @@ jobs:
           for n in $PR_NUMBERS; do
             echo "=== Checking PR #$n ==="
 
-            pr_json=$(gh pr view "$n" --json number,isDraft,author,labels,files)
+            pr_json=$(gh pr view "$n" --json number,state,isDraft,author,labels,files)
 
+            state=$(echo "$pr_json" | jq -r '.state')
             is_draft=$(echo "$pr_json" | jq -r '.isDraft')
             author_login=$(echo "$pr_json" | jq -r '.author.login')
             has_label=$(echo "$pr_json" | jq -r '[.labels[].name] | index("new tool version") != null')
             file_count=$(echo "$pr_json" | jq -r '.files | length')
             file_path=$(echo "$pr_json" | jq -r '.files[0].path // ""')
+
+            if [ "$state" != "OPEN" ]; then
+              echo "  [skip] Already $state (likely merged by a concurrent trigger for the same PR)"
+              continue
+            fi
 
             if [ "$is_draft" = "true" ]; then
               echo "  [skip] PR is a draft"


### PR DESCRIPTION
## Summary
- `gh pr edit --add-label "automated,new tool version"` in `check-bfx-releases.yml` fires a separate `labeled` webhook event per label added, so one call spawns two concurrent runs of `auto-merge-tool-versions.yml` for the same PR
- Both runs pass the eligibility check and race to call `gh pr merge`; the loser fails with `GraphQL: Merge already in progress (mergePullRequest)` (see PR #312's failed run, job `auto-merge` #73)
- Adds a `concurrency` group keyed on the PR number so triggers for the same PR run one at a time, and adds a `state != OPEN` check so a queued run skips cleanly instead of erroring if the PR was already merged by an earlier run

## Test plan
- [ ] Manually trigger `Check BFX Container Releases` again (or wait for next PR batch) and confirm no more "Merge already in progress" failures in `Auto-merge Tool Version PRs` runs