### PR TITLE
Update container version for alfred

### DIFF
--- a/bfx/alfred/release.json
+++ b/bfx/alfred/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/alfred:0.6.2--h3752d28_0",
     "quay.io/biocontainers/alfred:0.5.3--hd6466ae_0",
     "quay.io/biocontainers/alfred:0.5.1--h4d20210_0"
   ]


### PR DESCRIPTION
Updates the container version for alfred to match the latest Git release (0.6.2).