### PR TITLE
Update container version for breseq

### DIFF
--- a/bfx/breseq/release.json
+++ b/bfx/breseq/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/breseq:0.40.2--h3be2455_0",
     "quay.io/biocontainers/breseq:0.40.1--h3be2455_0",
     "quay.io/biocontainers/breseq:0.39.0--h077b44d_3"
   ]


### PR DESCRIPTION
Updates the container version for breseq to match the latest Git release (0.40.2).