### PR TITLE
Update container version for crispritz

### DIFF
--- a/bfx/crispritz/release.json
+++ b/bfx/crispritz/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/crispritz:2.7.0--py38h9948957_2"]}
+{
+  "images": [
+    "quay.io/biocontainers/crispritz:2.7.1--py38hc52dbad_0",
+    "quay.io/biocontainers/crispritz:2.7.0--py38h9948957_2"
+  ]
+}


### PR DESCRIPTION
Updates the container version for crispritz to match the latest Git release (2.7.1).