### PR TITLE
Update container version for gambit

### DIFF
--- a/bfx/gambit/release.json
+++ b/bfx/gambit/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/gambit:1.1.0--py312h247cb63_3"]}
+{
+  "images": [
+    "quay.io/biocontainers/gambit:1.2.0--py312hfabe715_0",
+    "quay.io/biocontainers/gambit:1.1.0--py312h247cb63_3"
+  ]
+}


### PR DESCRIPTION
Updates the container version for gambit to match the latest Git release (1.2.0).