### PR TITLE
Update container version for gseapy

### DIFF
--- a/bfx/gseapy/release.json
+++ b/bfx/gseapy/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/gseapy:1.3.0--py311heb3b1e3_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/gseapy:1.3.1--py312he7d644a_0",
+    "quay.io/biocontainers/gseapy:1.3.0--py311heb3b1e3_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for gseapy to match the latest Git release (1.3.1).