### PR TITLE
Update container version for hisat2

### DIFF
--- a/bfx/hisat2/release.json
+++ b/bfx/hisat2/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/hisat2:2.2.1--h503566f_8"]}
+{
+  "images": [
+    "quay.io/biocontainers/hisat2:2.2.3--h8471819_0",
+    "quay.io/biocontainers/hisat2:2.2.1--h503566f_8"
+  ]
+}


### PR DESCRIPTION
Updates the container version for hisat2 to match the latest Git release (2.2.3).