### PR TITLE
Update container version for salmon

### DIFF
--- a/bfx/salmon/release.json
+++ b/bfx/salmon/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/salmon:2.4.1--hfa8f182_0",
     "quay.io/biocontainers/salmon:2.3.4--hfa8f182_0",
     "quay.io/biocontainers/salmon:1.11.4--h7f96273_0",
     "quay.io/biocontainers/salmon:1.10.3--h45fbf2d_5"


### PR DESCRIPTION
Updates the container version for salmon to match the latest Git release (2.4.1).