### PR TITLE
Update container version for sopa

### DIFF
--- a/bfx/sopa/release.json
+++ b/bfx/sopa/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/sopa:2.2.10--pyhdfd78af_0",
     "quay.io/biocontainers/sopa:2.1.11--pyhdfd78af_0",
     "quay.io/biocontainers/sopa:2.1.10--pyhdfd78af_0",
     "quay.io/biocontainers/sopa:2.1.9--pyhdfd78af_0",


### PR DESCRIPTION
Updates the container version for sopa to match the latest Git release (2.2.10).