### PR TITLE
Update container version for bactopia

### DIFF
--- a/bfx/bactopia/release.json
+++ b/bfx/bactopia/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/bactopia:4.1.0--hdfd78af_0",
     "quay.io/biocontainers/bactopia:4.0.0--hdfd78af_0",
     "quay.io/biocontainers/bactopia:3.2.0--hdfd78af_0"
   ]


### PR DESCRIPTION
Updates the container version for bactopia to match the latest Git release (4.1.0).