### PR TITLE
Update container version for crossmap

### DIFF
--- a/bfx/crossmap/release.json
+++ b/bfx/crossmap/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/crossmap:0.7.3--pyhdfd78af_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/crossmap:0.7.4--pyhdfd78af_0",
+    "quay.io/biocontainers/crossmap:0.7.3--pyhdfd78af_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for crossmap to match the latest Git release (0.7.4).