### PR TITLE
Update container version for diamond

### DIFF
--- a/bfx/diamond/release.json
+++ b/bfx/diamond/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/diamond:2.2.5--he361c42_0",
     "quay.io/biocontainers/diamond:2.2.4--he361c42_0",
     "quay.io/biocontainers/diamond:2.1.25--he361c42_0"
   ]


### PR DESCRIPTION
Updates the container version for diamond to match the latest Git release (2.2.5).