### PR TITLE
Update container version for phyml

### DIFF
--- a/bfx/phyml/release.json
+++ b/bfx/phyml/release.json
@@ -1,1 +1,8 @@
-{"images": ["quay.io/biocontainers/phyml:3.3.20220408--h9bc3f66_3","quay.io/biocontainers/phyml:3.3.20211231--hee9e358_1","quay.io/biocontainers/phyml:3.3.20200621--hee9e358_2"]}
+{
+  "images": [
+    "quay.io/biocontainers/phyml:3.3.20260528--h34a2149_0",
+    "quay.io/biocontainers/phyml:3.3.20220408--h9bc3f66_3",
+    "quay.io/biocontainers/phyml:3.3.20211231--hee9e358_1",
+    "quay.io/biocontainers/phyml:3.3.20200621--hee9e358_2"
+  ]
+}


### PR DESCRIPTION
Updates the container version for phyml to match the latest Git release (3.3.20260528).