### PR TITLE
Update container version for alevin-fry

### DIFF
--- a/bfx/alevin-fry/release.json
+++ b/bfx/alevin-fry/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/alevin-fry:0.18.0--hd612981_0",
     "quay.io/biocontainers/alevin-fry:0.16.2--hd612981_0",
     "quay.io/biocontainers/alevin-fry:0.15.0--hd612981_0",
     "quay.io/biocontainers/alevin-fry:0.14.0--hd612981_0",


### PR DESCRIPTION
Updates the container version for alevin-fry to match the latest Git release (0.18.0).