### PR TITLE
Update container version for augur

### DIFF
--- a/bfx/augur/release.json
+++ b/bfx/augur/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/augur:34.1.3--pyhdfd78af_0",
     "quay.io/biocontainers/augur:34.1.2--pyhdfd78af_0",
     "quay.io/biocontainers/augur:34.1.1--pyhdfd78af_0",
     "quay.io/biocontainers/augur:34.0.0--pyhdfd78af_0",


### PR DESCRIPTION
Updates the container version for augur to match the latest Git release (34.1.3).