### PR TITLE
Update container version for cactus

### DIFF
--- a/bfx/cactus/release.json
+++ b/bfx/cactus/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/cactus:3.3.0--py311h8f07e81_0",
     "quay.io/biocontainers/cactus:3.1.4--py311h2f09395_0",
     "quay.io/biocontainers/cactus:3.0.1--py39h673081d_0"
   ]


### PR DESCRIPTION
Updates the container version for cactus to match the latest Git release (3.3.0).