### PR TITLE
Update container version for cellbender

### DIFF
--- a/bfx/cellbender/release.json
+++ b/bfx/cellbender/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/cellbender:0.3.2--pyhdfd78af_0"]}
+{
+  "images": [
+    "quay.io/biocontainers/cellbender:0.4.0--pyhdfd78af_0",
+    "quay.io/biocontainers/cellbender:0.3.2--pyhdfd78af_0"
+  ]
+}


### PR DESCRIPTION
Updates the container version for cellbender to match the latest Git release (0.4.0).