### PR TITLE
Update container version for falco

### DIFF
--- a/bfx/falco/release.json
+++ b/bfx/falco/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/falco:2.0.1--h3be2455_0",
     "quay.io/biocontainers/falco:1.3.2--h3be2455_0",
     "quay.io/biocontainers/falco:1.3.0--h3be2455_0",
     "quay.io/biocontainers/falco:1.2.5--h077b44d_0 ",


### PR DESCRIPTION
Updates the container version for falco to match the latest Git release (2.0.1).