### PR TITLE
Update container version for nextclade

### DIFF
--- a/bfx/nextclade/release.json
+++ b/bfx/nextclade/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/nextclade:3.22.0--h9ee0642_0",
     "quay.io/biocontainers/nextclade:3.21.2--h9ee0642_0",
     "quay.io/biocontainers/nextclade:3.20.0--h9ee0642_0",
     "quay.io/biocontainers/nextclade:3.19.0--h9ee0642_0",


### PR DESCRIPTION
Updates the container version for nextclade to match the latest Git release (3.22.0).