### PR TITLE
Update container version for cuttlefish

### DIFF
--- a/bfx/cuttlefish/release.json
+++ b/bfx/cuttlefish/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/cuttlefish:2.2.0--h6b3f7d6_5"]}
+{
+  "images": [
+    "quay.io/biocontainers/cuttlefish:3.0.1--hfa8f182_0",
+    "quay.io/biocontainers/cuttlefish:2.2.0--h6b3f7d6_5"
+  ]
+}


### PR DESCRIPTION
Updates the container version for cuttlefish to match the latest Git release (3.0.1).