### PR TITLE
Update container version for delly

### DIFF
--- a/bfx/delly/release.json
+++ b/bfx/delly/release.json
@@ -1,5 +1,6 @@
 {
   "images": [
+    "quay.io/biocontainers/delly:2.6.0--h3752d28_0",
     "quay.io/biocontainers/delly:2.5.1--h3752d28_0",
     "quay.io/biocontainers/delly:2.3.1--h3752d28_0",
     "quay.io/biocontainers/delly:1.7.3--hd6466ae_0",


### PR DESCRIPTION
Updates the container version for delly to match the latest Git release (2.6.0).