### PR TITLE
Update container version for ismapper

### DIFF
--- a/bfx/ismapper/release.json
+++ b/bfx/ismapper/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/ismapper:2.0--py_1"]}
+{
+  "images": [
+    "quay.io/biocontainers/ismapper:2.0.2--pyhdfd78af_0",
+    "quay.io/biocontainers/ismapper:2.0--py_1"
+  ]
+}


### PR DESCRIPTION
Updates the container version for ismapper to match the latest Git release (2.0.2).