### PR TITLE
Update container version for kmer-jellyfish

### DIFF
--- a/bfx/kmer-jellyfish/release.json
+++ b/bfx/kmer-jellyfish/release.json
@@ -1,1 +1,6 @@
-{"images": ["quay.io/biocontainers/kmer-jellyfish:1.1.12--h9948957_6"]}
+{
+  "images": [
+    "quay.io/biocontainers/kmer-jellyfish:2.3.1--py311pl5321he264feb_6",
+    "quay.io/biocontainers/kmer-jellyfish:1.1.12--h9948957_6"
+  ]
+}


### PR DESCRIPTION
Updates the container version for kmer-jellyfish to match the latest Git release (2.3.1).